### PR TITLE
fix: update bsconfig.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "rescript-intl",
+  "name": "@opendevtools/rescript-intl",
   "version": "0.0.0",
   "sources": [
     {


### PR DESCRIPTION
bsb complains when name in bsconfig.json differs from package.json:
```shell
File "/Volumes/Source/src/rescript-experiments/node_modules/@opendevtools/rescript-intl/bsconfig.json", line 2:
Error: package name is expected to be @opendevtools/rescript-intl but got rescript-intl
For more details, please checkout the schema https://rescript-lang.org/docs/manual/latest/build-configuration-schema
error Command failed with exit code 2.
```
Using bs-platform 9.0.1